### PR TITLE
[RF-22133] Fetch `rainforest-cli` from GitHub releases rather than Equinox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ jobs:
       script:
       # Install the latest stable version of rainforest-cli.
       # This will allow us to trigger a Rainforest run before we deploy.
-      - wget "https://bin.equinox.io/c/htRtQZagtfg/rainforest-cli-stable-linux-amd64.tgz"
-      - tar xvf rainforest-cli-stable-linux-amd64.tgz
-      - sudo mv rainforest /usr/local/bin/
+      - curl https://api.github.com/repos/rainforestapp/rainforest-cli/releases/latest | jq '.assets[].browser_download_url' | grep linux-amd64 | xargs wget -O rainforest-cli.tgz
+      - tar xvf rainforest-cli.tgz
+      - sudo mv rainforest-cli /usr/local/bin/rainforest
       # Trigger Rainforest run and wait for results
       - /usr/local/bin/rainforest run --run-group 7597 --token $RAINFOREST_TOKEN
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,8 +19,9 @@ pipeline {
 
         // Install the latest stable version of rainforest-cli.
         // This will allow us to trigger a Rainforest run before we deploy.
-        sh "wget 'https://bin.equinox.io/c/htRtQZagtfg/rainforest-cli-stable-linux-amd64.tgz'"
-        sh "tar xvf rainforest-cli-stable-linux-amd64.tgz"
+        sh "curl https://api.github.com/repos/rainforestapp/rainforest-cli/releases/latest | jq '.assets[].browser_download_url' | grep linux-amd64 | xargs wget -O rainforest-cli.tgz"
+        sh "tar xvf rainforest-cli.tgz"
+        sh "mv rainforest-cli rainforest"
       }
     }
 


### PR DESCRIPTION
Equinox will be shutting down next month, and no longer hosts releases of the Rainforest CLI as of `v2.21.1`. Moving forward, the way to download the Rainforest CLI will be via GitHub releases.