### PR TITLE
RF-22133 Use `jq`'s `-r` option to strip outer quotes from download URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
       script:
       # Install the latest stable version of rainforest-cli.
       # This will allow us to trigger a Rainforest run before we deploy.
-      - curl https://api.github.com/repos/rainforestapp/rainforest-cli/releases/latest | jq '.assets[].browser_download_url' | grep linux-amd64 | xargs wget -O rainforest-cli.tgz
+      - curl https://api.github.com/repos/rainforestapp/rainforest-cli/releases/latest | jq -r '.assets[].browser_download_url' | grep linux-amd64 | xargs wget -O rainforest-cli.tgz
       - tar xvf rainforest-cli.tgz
       - sudo mv rainforest-cli /usr/local/bin/rainforest
       # Trigger Rainforest run and wait for results

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
 
         // Install the latest stable version of rainforest-cli.
         // This will allow us to trigger a Rainforest run before we deploy.
-        sh "curl https://api.github.com/repos/rainforestapp/rainforest-cli/releases/latest | jq '.assets[].browser_download_url' | grep linux-amd64 | xargs wget -O rainforest-cli.tgz"
+        sh "curl https://api.github.com/repos/rainforestapp/rainforest-cli/releases/latest | jq -r '.assets[].browser_download_url' | grep linux-amd64 | xargs wget -O rainforest-cli.tgz"
         sh "tar xvf rainforest-cli.tgz"
         sh "mv rainforest-cli rainforest"
       }


### PR DESCRIPTION
`wget` on MacOS handles them just fine, but it chokes on Linux.