### PR TITLE
[SEO-102] Document GitHub Action workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,20 @@ orbs:
   heroku: circleci/heroku@1.1.1
 
 jobs:
+  check_chosen_ci:
+    docker:
+      - image: cimg/base:2020.01
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
+    steps:
+      - checkout
+      - run: |
+          ci=./script/pick_ci.sh
+          if [ $ci != "circleci" ] ; then
+            circleci-agent step-halt
+          fi
+
   test:
     docker:
       - image: circleci/ruby:2.7.1-node
@@ -60,6 +74,13 @@ workflows:
 
   test_and_merge:
     jobs:
+      - check_chosen_ci:
+          context:
+            - DockerHub
+          filters:
+            branches:
+              only: develop
+
       - test:
           context:
             - DockerHub
@@ -69,9 +90,8 @@ workflows:
       - heroku/deploy-via-git:
           name: deploy_staging
           app-name: rainforest-ci-sample-staging
-          filters:
-            branches:
-              only: develop
+          requires:
+            - check_chosen_ci
 
       # Run our Rainforest tests as above, but to be performed on any merge
       - rainforest/run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 0 16-31 * *"
           filters:
             branches:
               only: develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,15 +85,15 @@ workflows:
           context:
             - DockerHub
 
-      # Push our code to our staging or QA server. Depending on your hosting
-      # provider, this command would change. We're using Heroku here.
+      # Push our code to our staging or QA server. We're using Heroku here but you will need
+      # to change this to match how you deploy your releases.
       - heroku/deploy-via-git:
           name: deploy_staging
           app-name: rainforest-ci-sample-staging
           requires:
             - check_chosen_ci
 
-      # Run our Rainforest tests as above, but to be performed on any merge
+      # Run our Rainforest tests as above, but to be performed on any merge.
       - rainforest/run:
           name: run_rainforest
           run_group_id: ${RELEASE_RUN_GROUP_ID:-2401}
@@ -104,8 +104,8 @@ workflows:
           requires:
             - deploy_staging
 
-      # Our Rainforest build was successful! Push the code to the master branch
-      # which will kick another circle build deploying our code to production.
+      # Our Rainforest build was successful! Push the code to the master branch which
+      # will start another CircleCI workflow that will deploy our code to production.
       - merge_to_master:
           requires:
             - run_rainforest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ on:
     branches: [develop]
 
 jobs:
-  # Our sample repo has no tests, but this is where you would include your unit
-  # tests, to be run in parallel to your Rainforest tests.
+  # Our sample repo has no tests but this is where you would include your unit
+  # tests to run concurrently with your Rainforest tests.
   test:
     runs-on: ubuntu-latest
     steps:
@@ -17,8 +17,8 @@ jobs:
         env:
           RACK_ENV: test
 
-  # This sample repo has functional GitHub Actions and CircleCI workflows. In order to avoid
-  # conflicts, we only use one tool for each release.
+  # This sample repo has functional GitHub Actions and CircleCI workflows. To avoid conflicts
+  # we only use one tool for each release.
   pick_ci:
     outputs:
       chosen_ci: ${{ steps.pick_ci.outputs.chosen_ci }}
@@ -29,8 +29,8 @@ jobs:
           ci=./script/pick_ci.sh
           echo "::set-output name=chosen_ci::$ci"
 
-  # Push our code to our staging or QA server. Depending on your hosting
-  # provider, this command would change. We're using Heroku here.
+  # Push our code to our staging or QA server. We're using Heroku here but you will need to
+  # change this to match how you deploy your releases.
   deploy_staging:
     runs-on: ubuntu-latest
     needs: pick_ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,64 @@
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  # Our sample repo has no tests, but this is where you would include your unit
+  # tests, to be run in parallel to your Rainforest tests.
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Run Tests
+        run: bundle exec rake
+        env:
+          RACK_ENV: test
+
+  # Push our code to our staging or QA server. Depending on your hosting
+  # provider, this command would change. We're using Heroku here.
+  deploy_staging:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.12.12
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: rainforest-ci-sample-staging
+          heroku_email: ${{ secrets.HEROKU_EMAIL }}
+
+  # Run our Rainforest tests. `run_group_id` should point to the Run Group you
+  # want to use for your releases. See the action documentation for additional
+  # options you can use: https://github.com/marketplace/actions/rainforest-qa-github-action
+  run_rainforest:
+    runs-on: ubuntu-latest
+    needs: deploy_staging
+    steps:
+      - uses: rainforestapp/github-action@v1
+        with:
+          token: ${{ secrets.RAINFOREST_TOKEN }}
+          run_group_id: 7597
+
+  # Our Rainforest build was successful! Push the code to the master branch.
+  merge_to_master:
+    runs-on: ubuntu-latest
+    needs: [test, run_rainforest]
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v2
+      - run: git push origin $GITHUB_SHA:refs/heads/master
+
+  # Now that the master branch has been updated, deploy to production.
+  deploy_production:
+    runs-on: ubuntu-latest
+    needs: merge_to_master
+    steps:
+      - uses: actions/checkout@v2
+      - uses: akhileshns/heroku-deploy@v3.12.12
+        with:
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: rainforest-ci-sample-prd
+          heroku_email: ${{ secrets.HEROKU_EMAIL }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,24 @@ jobs:
         env:
           RACK_ENV: test
 
+  # This sample repo has functional GitHub Actions and CircleCI workflows. In order to avoid
+  # conflicts, we only use one tool for each release.
+  pick_ci:
+    outputs:
+      chosen_ci: ${{ steps.pick_ci.outputs.chosen_ci }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          ci=./script/pick_ci.sh
+          echo "::set-output name=chosen_ci::$ci"
+
   # Push our code to our staging or QA server. Depending on your hosting
   # provider, this command would change. We're using Heroku here.
   deploy_staging:
     runs-on: ubuntu-latest
+    needs: pick_ci
+    if: pick_ci.outputs.chosen_ci == 'github-actions'
     steps:
       - uses: actions/checkout@v2
       - uses: akhileshns/heroku-deploy@v3.12.12

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,0 +1,16 @@
+on:
+  schedule:
+    - cron: '0 0 1-15 * *'
+
+jobs:
+  # Run our Rainforest tests. `run_group_id` should point to the Run Group you
+  # want to use for your releases. See the action documentation for additional
+  # options you can use: https://github.com/marketplace/actions/rainforest-qa-github-action
+  run_rainforest:
+    runs-on: ubuntu-latest
+    needs: deploy_staging
+    steps:
+      - uses: rainforestapp/github-action@v1
+        with:
+          token: ${{ secrets.RAINFOREST_TOKEN }}
+          run_group_id: 7597

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Continuous Delivery with Rainforest QA [![Rainforest QA](https://circleci.com/gh/rainforestapp/ci-sample.svg?style=shield)](https://circleci.com/gh/rainforestapp/workflows/ci-sample)
+# Continuous Delivery with Rainforest QA [![Rainforest QA](https://circleci.com/gh/rainforestapp/ci-sample.svg?style=shield)](https://circleci.com/gh/rainforestapp/workflows/ci-sample) ![release](https://github.com/rainforestapp/ci-sample/actions/workflows/release.yml/badge.svg)
 
 Common CI tools can be configured to automatically run your Rainforest tests as part of your release process, allowing you to prevent regressions that aren't caught by unit tests before they reach your users.
 ## How does this work?
 
 This repository provides several examples of how you might configure your CI tool of choice to automatically run Rainforest tests as part of your release process.
-There are working sample configurations for three common CI tools ([CircleCI](./.circleci/config.yml), [Jenkins](./Jenkinsfile) and [Travis CI](./.travis.yml)), all of which assume the following workflow:
+There are working sample configurations for three common CI tools ([CircleCI](./.circleci/config.yml), [GitHub Actions](./.github/workflows/release.yml), [Jenkins](./Jenkinsfile) and [Travis CI](./.travis.yml)), all of which assume the following workflow:
 
 - All developers start new work by branching off of `develop`. Devs would create a new feature branch for each shippable piece of code.
 

--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ There are working sample configurations for three common CI tools ([CircleCI](./
 This is a simple and effective way of preventing regressions by automatically running both unit tests and your Rainforest test suite. The sample workflows can be modified for your application and run as-is, or can be easily extended to fit the requirements for your specific release workflow.
 
 ## CI Server Tested
-We test our sample configuration nightly via [CircleCI](https://circleci.com/). View our [configuration file](./.circleci/config.yml).
+We test our sample configuration nightly via [CircleCI](https://circleci.com/) and [GitHub Actions](https://docs.github.com/en/actions). View our configuration files for [CircleCI](./.circleci/config.yml) and [GitHub Actions](./.github/workflows/schedule.yml).

--- a/script/pick_ci.sh
+++ b/script/pick_ci.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# This script returns a CI service name based on the most recent commit. If we ever want to add a third
+# service, we need to update the modulo on the line below.
+case "$(( 0x$(git rev-parse HEAD | cut -c1) % 2 ))" in
+  0) echo "circleci"
+  ;;
+  1) echo "github-actions"
+  ;;
+esac


### PR DESCRIPTION
This adds a GitHub workflow showing how to use the action, then splits the scheduled and release workflows to only happen via CircleCI or GitHub Actions, rather than across both in parallel.

For the GitHub workflow to work, we'll need to set the following secrets:
- [x] `RAINFOREST_TOKEN`
- [x] `HEROKU_API_KEY`
- [x] `HEROKU_EMAIL`

An alternative would be to simply not run the GitHub workflows? We can do that by removing the `schedule.yml` workflow and replacing the reference to the `develop` branch in `release.yml` with some nonexistent branch.
