### PR TITLE
[SEO-102] Use proper setup-ruby action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
       - name: Run Tests


### PR DESCRIPTION
Should be the final fix to #27. I referenced the deprecated `actions/setup-ruby` action rather than the `ruby/setup-ruby` action that replaced it. That broke because the `bundler_cache` parameter doesn't exist in the former.