### PR TITLE
[SEO-102] Still more fixes for dual-CI building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,21 +7,18 @@ orbs:
   rainforest: rainforest-qa/rainforest@3
   heroku: circleci/heroku@1.1.1
 
-jobs:
+commands:
   check_chosen_ci:
-    docker:
-      - image: cimg/base:2020.01
-        auth:
-          username: $DOCKERHUB_USERNAME
-          password: $DOCKERHUB_TOKEN
     steps:
-      - checkout
-      - run: |
-          ci=./script/pick_ci.sh
-          if [ $ci != "circleci" ] ; then
-            circleci-agent step halt
-          fi
-
+      - run:
+          name: Pick CI
+          command: |
+            ci=$(script/pick_ci.sh)
+            echo "Picked $ci"
+            if [ $ci != "circleci" ] ; then
+              circleci-agent step halt
+            fi
+jobs:
   test:
     docker:
       - image: circleci/ruby:2.7.1-node
@@ -38,6 +35,18 @@ jobs:
       - run: bundle install
       - run: bundle exec rake
 
+  run_rainforest:
+    executor: rainforest/default
+    steps:
+      - checkout
+      - check_chosen_ci
+      - rainforest/run_qa: # Command provided by the Orb, to be used in your own jobs
+          run_group_id: ${RELEASE_RUN_GROUP_ID:-2401}
+          environment_id: ${RELEASE_ENVIRONMENT_ID:-343}
+          crowd: ${RELEASE_CROWD:-default}
+          conflict: abort
+          pipeline_id: << pipeline.id >>
+
   merge_to_master:
     docker:
       - image: cimg/base:2020.01
@@ -46,6 +55,7 @@ jobs:
           password: $DOCKERHUB_TOKEN
     steps:
       - checkout
+      - check_chosen_ci
       - run: git push origin $CIRCLE_SHA1:refs/heads/master
 
 workflows:
@@ -62,7 +72,7 @@ workflows:
       # Run our Rainforest tests. `run_group_id` should point to the Run Group you
       # want to use for your releases. `environment_id` should point to your Staging or QA
       # environment.
-      - rainforest/run:
+      - rainforest/run: # Job provided by the orb, to be used in your workflows
           name: run_rainforest
           run_group_id: ${RELEASE_RUN_GROUP_ID:-2401}
           environment_id: ${RELEASE_ENVIRONMENT_ID:-343}
@@ -74,13 +84,6 @@ workflows:
 
   test_and_merge:
     jobs:
-      - check_chosen_ci:
-          context:
-            - DockerHub
-          filters:
-            branches:
-              only: develop
-
       - test:
           context:
             - DockerHub
@@ -90,17 +93,14 @@ workflows:
       - heroku/deploy-via-git:
           name: deploy_staging
           app-name: rainforest-ci-sample-staging
-          requires:
+          pre-deploy:
             - check_chosen_ci
+          filters:
+            branches:
+              only: develop
 
       # Run our Rainforest tests as above, but to be performed on any merge.
-      - rainforest/run:
-          name: run_rainforest
-          run_group_id: ${RELEASE_RUN_GROUP_ID:-2401}
-          environment_id: ${RELEASE_ENVIRONMENT_ID:-343}
-          crowd: ${RELEASE_CROWD:-default}
-          conflict: abort
-          pipeline_id: << pipeline.id >>
+      - run_rainforest:
           requires:
             - deploy_staging
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          ci=./script/pick_ci.sh
+      - id: pick_ci
+        name: Pick CI
+        run: |
+          ci=$(script/pick_ci.sh)
+          echo "Picked $ci"
           echo "::set-output name=chosen_ci::$ci"
 
   # Push our code to our staging or QA server. We're using Heroku here but you will need to


### PR DESCRIPTION
This fixes a couple of issues:
1. We were always setting `ci` to `"./script/pick_ci.sh"` rather than to the output of the script 🤦🏼 
2. This value wasn't properly set on the job in GitHub since the step it was generated in had no ID. This meant that, even if 1. weren't an issue, we would never release via GitHub
3. We were always releasing via CircleCI due to https://discuss.circleci.com/t/does-circleci-step-halt-works-with-version-2-1/36674/4

I properly tested it this time 🤦🏼 I did so by pushing [this commit](https://github.com/rainforestapp/ci-sample/commit/021b9ad8547929301fed122e73a8fe5aaf294cf4), which had the following builds:
- GitHub: https://github.com/rainforestapp/ci-sample/runs/4591169026?check_suite_focus=true#step:3:6
- CircleCI: https://app.circleci.com/pipelines/github/rainforestapp/ci-sample/179/workflows/2599f2d4-4544-4ff3-9650-a004bb1941da/jobs/383/parallel-runs/0/steps/0-104