### PR TITLE
[SEO-102] Properly kick off RF run from Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,9 @@ workflows:
             - run_rainforest
           context:
             - DockerHub
+          filters:
+            branches:
+              only: develop
 
   release:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ workflows:
       # Job provided by the Orb to run your tests.
       # This accepts the same parameters as the `rainforest/run_qa` command (see above).
       - rainforest/run:
-          name: run_rainforest
+          name: run_rainforest_nightly
           run_group_id: ${RELEASE_RUN_GROUP_ID:-2401}
           environment_id: ${RELEASE_ENVIRONMENT_ID:-343}
           crowd: ${RELEASE_CROWD:-default}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,10 +36,17 @@ jobs:
       - run: bundle exec rake
 
   run_rainforest:
-    executor: rainforest/default
+    docker:
+      - image: cimg/base:2021.12
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
     steps:
       - checkout
       - check_chosen_ci
+      - run: mkdir -p /home/circleci/.local/bin
+      - rainforest/install:
+          install_path: /home/circleci/.local/bin
       - rainforest/run_qa: # Command provided by the Orb, to be used in your own jobs
           run_group_id: ${RELEASE_RUN_GROUP_ID:-2401}
           environment_id: ${RELEASE_ENVIRONMENT_ID:-343}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,10 @@ jobs:
       - checkout
       - check_chosen_ci
       - run: mkdir -p /home/circleci/.local/bin
+      - restore_cache:
+          keys:
+            - rainforest-run-{{ .Revision }}-{{ .BuildNum }}
+            - rainforest-run-{{ .Revision }}-
       # Command provided by the Orb to install the CLI.
       # This is only needed if you do not use the `rainforest/run` job (see below) or the
       # `rainforest/default` executor (https://circleci.com/developer/orbs/orb/rainforest-qa/rainforest#executors).
@@ -63,6 +67,15 @@ jobs:
           # Passing in the pipeline ID enables rerunning only failed Rainforest tests when
           # rerunning a failed CircleCI build.
           pipeline_id: << pipeline.id >>
+      # Command to save the created run's ID. Together with the `restore_cache` and `save_cache` steps,
+      # this allows you to rerun only failed tests when rerunning a failed workflow.
+      - rainforest/save_run_id:
+          pipeline_id: << pipeline.id >>
+      - save_cache:
+          when: on_fail
+          key: rainforest-run-{{ .Revision }}-{{ .BuildNum }}
+          paths:
+            - ~/pipeline
 
   merge_to_master:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
       - run: bundle install
       - run: bundle exec rake
 
+  # This job shows how to use commands provided by the Orb to run your Rainforest tests.
   run_rainforest:
     docker:
       - image: cimg/base:2021.12
@@ -45,13 +46,22 @@ jobs:
       - checkout
       - check_chosen_ci
       - run: mkdir -p /home/circleci/.local/bin
+      # Command provided by the Orb to install the CLI.
+      # This is only needed if you do not use the `rainforest/run` job (see below) or the
+      # `rainforest/default` executor (https://circleci.com/developer/orbs/orb/rainforest-qa/rainforest#executors).
       - rainforest/install:
           install_path: /home/circleci/.local/bin
-      - rainforest/run_qa: # Command provided by the Orb, to be used in your own jobs
+      # Command to run your tests. `run_group_id` should point to the Run Group you
+      # want to use for your releases. `environment_id` should point to your Staging or QA
+      # environment. See the docs for a full list of parameters:
+      # https://circleci.com/developer/orbs/orb/rainforest-qa/rainforest#commands-run_qa
+      - rainforest/run_qa:
           run_group_id: ${RELEASE_RUN_GROUP_ID:-2401}
           environment_id: ${RELEASE_ENVIRONMENT_ID:-343}
           crowd: ${RELEASE_CROWD:-default}
           conflict: abort
+          # Passing in the pipeline ID enables rerunning only failed Rainforest tests when
+          # rerunning a failed CircleCI build.
           pipeline_id: << pipeline.id >>
 
   merge_to_master:
@@ -76,17 +86,14 @@ workflows:
               only: develop
     jobs:
       - test
-      # Run our Rainforest tests. `run_group_id` should point to the Run Group you
-      # want to use for your releases. `environment_id` should point to your Staging or QA
-      # environment.
-      - rainforest/run: # Job provided by the orb, to be used in your workflows
+      # Job provided by the Orb to run your tests.
+      # This accepts the same parameters as the `rainforest/run_qa` command (see above).
+      - rainforest/run:
           name: run_rainforest
           run_group_id: ${RELEASE_RUN_GROUP_ID:-2401}
           environment_id: ${RELEASE_ENVIRONMENT_ID:-343}
           crowd: ${RELEASE_CROWD:-default}
           conflict: abort
-          # Passing in the pipeline ID enables rerunning only failed Rainforest tests when
-          # rerunning a failed CircleCI build.
           pipeline_id: << pipeline.id >>
 
   test_and_merge:


### PR DESCRIPTION
This is currently broken because we need `git` to check the SHA when picking which CI service to use, and the `run_rainforest` job is using the `rainforest/default` executor, which has the CLI preinstalled—_but not `git`_.

Tested in https://app.circleci.com/pipelines/github/rainforestapp/ci-sample/190/workflows/427c8cf6-30e7-4ecb-aab1-559c639fac3b/jobs/409