### PR TITLE
[SEO-102] Fix merging to master from GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - run: git push origin $GITHUB_SHA:refs/heads/master
 
   # Now that the master branch has been updated, deploy to production.


### PR DESCRIPTION
`actions/checkout` does a shallow clone by default, which doesn't let you push. We need this for the `merge_to_master` job. 