### PR TITLE
Fix more GH deprecations, add dependabot for GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+- package-ecosystem: bundler
+  directory: "/"
+  schedule:
+    interval: weekly
+
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: deploy_staging
     steps:
-      - uses: rainforestapp/github-action@v1
+      - uses: rainforestapp/github-action@v3
         with:
           token: ${{ secrets.RF_MAIN_API_TOKEN }}
           run_group_id: 7597


### PR DESCRIPTION
#40 failed because the token wasn't available to this repo. This has since been fixed, but while investigating I noticed we were using an old version of the GH action.